### PR TITLE
Generate selfLink when not available (#69)

### DIFF
--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -782,3 +782,15 @@ func TestGetLiveManifestFilteredForUserProvidedOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateSelfLink(t *testing.T) {
+	// general case
+	link := generateSelfLink("v1", "ns", "kind", "name")
+	assert.Equal(t, link, "/apis/v1/namespaces/ns/kinds/name")
+	// no-namespace case
+	link = generateSelfLink("v1", "", "kind", "name")
+	assert.Equal(t, link, "/apis/v1/kinds/name")
+	// plural kind adds 'es'
+	link = generateSelfLink("v1", "ns", "kinds", "name")
+	assert.Equal(t, link, "/apis/v1/namespaces/ns/kindses/name")
+}


### PR DESCRIPTION
Kubernetes 1.20+ no longer generates a selfLink for Kubernetes objects.
This value is used as a Terraform resource ID.

If there is no selfLink on the object, this patch generates one in the
same format (`/apis/<apiVersion>/namespaces/<namespace>/<kind>s/<name>`)
and uses that as the Terraform resource ID.

--- 
I took a cue from [this issue](https://github.com/lensapp/lens/pull/1804/files) for the implementation. 

I tested it on my failing use case with a `k3s with k8s 1.20 api` cluster and it fixed my case.  It also worked with earlier K8S API versions that include the `selfLink`.     I tried to run the acceptance tests, but didn't get a fully clean run, but maybe that's my environment.

Thanks for this provider -- it is such a natural way to manage these K8S resources!