### PR TITLE
Fix missing `}` in the kubectl_manifest example

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -30,6 +30,7 @@ spec:
           serviceName: test
           servicePort: 80
 YAML
+}
 ```
 
 > Note: When the kind is a Deployment, this provider will wait for the deployment to be rolled out automatically for you!


### PR DESCRIPTION
Minor change.
The `kubectl_manifest` is missing a `}` to close the resource definition.