### PR TITLE
Support kubectl replace --force

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -44,6 +44,7 @@ YAML
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
 * `wait` - Optional. Set this flag to wait or not for finalized to complete for deleted objects. Default `false`.
 * `wait_for_rollout` - Optional. Set this flag to wait or not for Deployments and APIService to complete rollout. Default `true`.
+* `replace` - Optional. Set this flag to do a `kubectl replace --force` instead of apply. Default `false`.
 
 ## Attribute Reference
 

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -44,7 +44,7 @@ YAML
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.
 * `wait` - Optional. Set this flag to wait or not for finalized to complete for deleted objects. Default `false`.
 * `wait_for_rollout` - Optional. Set this flag to wait or not for Deployments and APIService to complete rollout. Default `true`.
-* `replace` - Optional. Set this flag to do a `kubectl replace --force` instead of apply. Default `false`.
+* `force_replace` - Optional. Set this flag to do a `kubectl replace --force` instead of apply. Default `false`.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/cenkalti/backoff v2.1.1+incompatible
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/terraform v0.12.29
@@ -14,6 +15,8 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/zclconf/go-cty v1.2.1
 	github.com/zclconf/go-cty-yaml v1.0.1
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.32.0
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.18.12

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -59,7 +59,7 @@ func resourceKubectlManifest() *schema.Resource {
 			if kubectlApplyRetryCount > 0 {
 				retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
 				retryErr := backoff.Retry(func() error {
-					if d.Get("replace").(bool) {
+					if d.Get("force_replace").(bool) {
 						err := resourceKubectlManifestReplace(ctx, d, meta)
 						if err != nil {
 							log.Printf("[ERROR] creating manifest failed: %+v", err)
@@ -80,7 +80,7 @@ func resourceKubectlManifest() *schema.Resource {
 
 				return nil
 			} else {
-				if d.Get("replace").(bool) {
+				if d.Get("force_replace").(bool) {
 					if replaceErr := resourceKubectlManifestReplace(ctx, d, meta); replaceErr != nil {
 						return diag.FromErr(replaceErr)
 					}
@@ -115,7 +115,7 @@ func resourceKubectlManifest() *schema.Resource {
 			if kubectlApplyRetryCount > 0 {
 				retryConfig := backoff.WithMaxRetries(exponentialBackoffConfig, kubectlApplyRetryCount)
 				retryErr := backoff.Retry(func() error {
-					if d.Get("replace").(bool) {
+					if d.Get("force_replace").(bool) {
 						err := resourceKubectlManifestReplace(ctx, d, meta)
 						if err != nil {
 							log.Printf("[ERROR] updating manifest failed: %+v", err)
@@ -136,7 +136,7 @@ func resourceKubectlManifest() *schema.Resource {
 
 				return nil
 			} else {
-				if d.Get("replace").(bool) {
+				if d.Get("force_replace").(bool) {
 					if applyErr := resourceKubectlManifestReplace(ctx, d, meta); applyErr != nil {
 						return diag.FromErr(applyErr)
 					}
@@ -463,9 +463,9 @@ metadata:
 				Optional:    true,
 				Default:     true,
 			},
-			"replace": {
+			"force_replace": {
 				Type:        schema.TypeBool,
-				Description: "Default to false (replace). Set this flag to do a 'kubectl replace --force' instead of apply.",
+				Description: "Default to false (force_replace). Set this flag to do a 'kubectl replace --force' instead of apply.",
 				Optional:    true,
 				Default:     true,
 			},

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -467,7 +467,7 @@ metadata:
 				Type:        schema.TypeBool,
 				Description: "Default to false (force_replace). Set this flag to do a 'kubectl replace --force' instead of apply.",
 				Optional:    true,
-				Default:     true,
+				Default:     false,
 			},
 		},
 	}


### PR DESCRIPTION
This PR will add a new feature to be able to execute a `kubectl replace --force` instead of a `kubectl apply`.

This feature it's important when you are applying large files. When you use `kubectl apply` with large files you will get a error like this `metadata.annotations: Too long: must have at most 262144 bytes` a workaround it's to use `replace`.
