### PR TITLE
Support darwin_arm64 package

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,40 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Upload assets
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*


### PR DESCRIPTION
Hi, I'm trying to fix #103

I think it just need to be rebuild using go 1.6, see [here](https://github.com/terraform-aws-modules/terraform-provider-http/commit/17a883113b478767c1ab36fafd9f6af7a6ffbb36#) and [here](https://goreleaser.com/ci/actions/).

Set GPG_PRIVATE_KEY and PASSPHRASE secret in rep settings and just make a release and tag it, *Github Actions* will build new packages for you.


![image](https://user-images.githubusercontent.com/20437334/119017813-f84a8680-b9cd-11eb-9ce5-450c9268cde0.png)

