### PR TITLE
Update kubectl_path_documents example doc.

### DIFF
--- a/docs/data-sources/kubectl_path_documents.md
+++ b/docs/data-sources/kubectl_path_documents.md
@@ -19,7 +19,7 @@ data "kubectl_path_documents" "docs" {
 }
 
 resource "kubectl_manifest" "test" {
-    for_each  = data.kubectl_file_documents.docs.manifests
+    for_each  = toset(data.kubectl_path_documents.docs.documents)
     yaml_body = each.value
 }
 ```


### PR DESCRIPTION
Example uses kubectl_file_documents instead of kubectl_path_documents.
[for_each](https://www.terraform.io/docs/language/meta-arguments/for_each.html#basic-syntax) has to be a set or a map and thus toset() is needed.
This update closes #135.