### PR TITLE
Add apply_only argument. Add force_conflicts option.

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -42,6 +42,7 @@ YAML
 * `sensitive_fields` - Optional. List of fields (dot-syntax) which are sensitive and should be obfuscated in output. Defaults to `["data"]` for Secrets.
 * `force_new` - Optional. Forces delete & create of resources if the `yaml_body` changes. Default `false`.
 * `server_side_apply` - Optional. Allow using server-side-apply method. Default `false`.
+* `apply_only` - Optional. It does not delete resource in any case Default `false`.
 * `ignore_fields` - Optional. List of map fields to ignore when applying the manifest. See below for more details.
 * `override_namespace` - Optional. Override the namespace to apply the kubernetes resource to, ignoring any declared namespace in the `yaml_body`.
 * `validate_schema` - Optional. Setting to `false` will mimic `kubectl apply --validate=false` mode. Default `true`.

--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -42,6 +42,7 @@ YAML
 * `sensitive_fields` - Optional. List of fields (dot-syntax) which are sensitive and should be obfuscated in output. Defaults to `["data"]` for Secrets.
 * `force_new` - Optional. Forces delete & create of resources if the `yaml_body` changes. Default `false`.
 * `server_side_apply` - Optional. Allow using server-side-apply method. Default `false`.
+* `force_conflicts` - Optional. Allow using force_conflicts. Default `false`.
 * `apply_only` - Optional. It does not delete resource in any case Default `false`.
 * `ignore_fields` - Optional. List of map fields to ignore when applying the manifest. See below for more details.
 * `override_namespace` - Optional. Override the namespace to apply the kubernetes resource to, ignoring any declared namespace in the `yaml_body`.
@@ -74,7 +75,7 @@ resource "kubectl_manifest" "test" {
     sensitive_fields = [
         "metadata.annotations.my-secret-annotation"
     ]
-    
+
     yaml_body = <<YAML
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -400,6 +400,12 @@ var (
 			Optional:    true,
 			Default:     false,
 		},
+		"force_conflicts": {
+			Type:        schema.TypeBool,
+			Description: "Default false.",
+			Optional:    true,
+			Default:     false,
+		},
 		"apply_only": {
 			Type:        schema.TypeBool,
 			Description: "Apply only. In other words, it does not delete resource in any case.",
@@ -486,6 +492,10 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 	if d.Get("server_side_apply").(bool) {
 		applyOptions.ServerSideApply = true
 		applyOptions.FieldManager = "kubectl"
+	}
+
+	if d.Get("force_conflicts").(bool) {
+		applyOptions.ForceConflicts = true
 	}
 
 	if manifest.HasNamespace() {

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -83,9 +83,6 @@ func resourceKubectlManifest() *schema.Resource {
 			return nil
 		},
 		DeleteContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-			if d.Get("apply_only").(bool) {
-				return nil
-			}
 			if err := resourceKubectlManifestDelete(ctx, d, meta); err != nil {
 				return diag.FromErr(err)
 			}
@@ -616,6 +613,9 @@ func resourceKubectlManifestReadUsingClient(ctx context.Context, d *schema.Resou
 }
 
 func resourceKubectlManifestDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+	if d.Get("apply_only").(bool) {
+		return nil
+	}
 	yamlBody := d.Get("yaml_body").(string)
 	manifest, err := yaml.ParseYAML(yamlBody)
 	if err != nil {

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -83,6 +83,9 @@ func resourceKubectlManifest() *schema.Resource {
 			return nil
 		},
 		DeleteContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			if d.Get("apply_only").(bool) {
+				return nil
+			}
 			if err := resourceKubectlManifestDelete(ctx, d, meta); err != nil {
 				return diag.FromErr(err)
 			}
@@ -187,6 +190,7 @@ metadata:
 				_ = d.Set("name", metaObjLive.GetName())
 				_ = d.Set("force_new", false)
 				_ = d.Set("server_side_apply", false)
+				_ = d.Set("apply_only", false)
 
 				// clear out fields user can't set to try and get parity with yaml_body
 				meta_v1_unstruct.RemoveNestedField(metaObjLive.Raw.Object, "metadata", "creationTimestamp")
@@ -393,6 +397,12 @@ var (
 		"server_side_apply": {
 			Type:        schema.TypeBool,
 			Description: "Default to client-side-apply. Setting to true will use server-side apply.",
+			Optional:    true,
+			Default:     false,
+		},
+		"apply_only": {
+			Type:        schema.TypeBool,
+			Description: "Apply only. In other words, it does not delete resource in any case.",
 			Optional:    true,
 			Default:     false,
 		},


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html

Some cloud providers have resources such as `aws-auth` configmap that can be applied but never deleted permanently.
It would be smart to handle such cases as well.