### PR TITLE
feat: Allow field manager to be user defined

### DIFF
--- a/docs/resources/kubectl_manifest.md
+++ b/docs/resources/kubectl_manifest.md
@@ -42,6 +42,7 @@ YAML
 * `sensitive_fields` - Optional. List of fields (dot-syntax) which are sensitive and should be obfuscated in output. Defaults to `["data"]` for Secrets.
 * `force_new` - Optional. Forces delete & create of resources if the `yaml_body` changes. Default `false`.
 * `server_side_apply` - Optional. Allow using server-side-apply method. Default `false`.
+* `field_manager` - Optional. Override the default field manager name. This is only relevent when using server-side apply. Default `kubectl`.
 * `force_conflicts` - Optional. Allow using force_conflicts. Default `false`.
 * `apply_only` - Optional. It does not delete resource in any case Default `false`.
 * `ignore_fields` - Optional. List of map fields to ignore when applying the manifest. See below for more details.

--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -4,19 +4,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/gavinbunney/terraform-provider-kubectl/flatten"
 	"github.com/gavinbunney/terraform-provider-kubectl/yaml"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"io/ioutil"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/validation"
-	"os"
-	"sort"
-	"time"
-
-	"log"
-	"strings"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8sresource "k8s.io/cli-runtime/pkg/resource"
@@ -397,6 +397,12 @@ var (
 			Optional:    true,
 			Default:     false,
 		},
+		"field_manager": {
+			Type:        schema.TypeString,
+			Description: "Override the default field manager name. This is only relevent when using server-side apply.",
+			Optional:    true,
+			Default:     "kubectl",
+		},
 		"force_conflicts": {
 			Type:        schema.TypeBool,
 			Description: "Default false.",
@@ -488,7 +494,7 @@ func resourceKubectlManifestApply(ctx context.Context, d *schema.ResourceData, m
 
 	if d.Get("server_side_apply").(bool) {
 		applyOptions.ServerSideApply = true
-		applyOptions.FieldManager = "kubectl"
+		applyOptions.FieldManager = d.Get("field_manager").(string)
 	}
 
 	if d.Get("force_conflicts").(bool) {


### PR DESCRIPTION
It would be useful to be able to set a custom [field manager](https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management) when using server-side apply.

This builds on top of the work done in  #148 to enable forcing changes.

Fixes #139.