### PR TITLE
Fix kubectl_path_documents.md documentation

### DIFF
--- a/docs/data-sources/kubectl_path_documents.md
+++ b/docs/data-sources/kubectl_path_documents.md
@@ -19,7 +19,7 @@ data "kubectl_path_documents" "docs" {
 }
 
 resource "kubectl_manifest" "test" {
-    for_each  = toset(data.kubectl_path_documents.docs.documents)
+    for_each  = data.kubectl_path_documents.docs.manifests
     yaml_body = each.value
 }
 ```
@@ -163,7 +163,6 @@ metadata:
 ## Argument Reference
 
 * `pattern` - Required. Glob pattern to search for.
-* `force_new` - Optional. Forces delete & create of resources if the `yaml_body` changes. Default `false`.
 * `vars` - Optional. Map of variables to use when rendering the loaded documents as templates. Currently only strings are supported.
 * `sensitive_vars` - Optional. Map of sensitive variables to use when rendering the loaded documents as templates. Merged with the `vars` attribute. Currently only strings are supported.
 * `disable_template` - Optional. Flag to disable template parsing of the loaded documents.


### PR DESCRIPTION
* Revert #140 as the original documentation was correct
* Remove invalid argument

I agree with the comment https://github.com/gavinbunney/terraform-provider-kubectl/pull/140#issuecomment-1117142004