### PR TITLE
Add `proxy_url` configuration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.dll
 *.exe
 .DS_Store
+.vscode
 example.tf
 terraform.tfplan
 terraform.tfstate

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,6 +90,7 @@ The following arguments are supported:
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
+* `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
     * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
     * `command` - (Required) Command to execute.


### PR DESCRIPTION
## Description

Adds support for proxy_url of the provider. This functions identically to the [same parameter in the kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#proxy_url).

Fixes https://github.com/gavinbunney/terraform-provider-kubectl/issues/178