### PR TITLE
fix: prevent inconsistent planning

### DIFF
--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -220,6 +220,8 @@ metadata:
 
 			if !d.NewValueKnown("yaml_body") {
 				log.Printf("[TRACE] yaml_body value interpolated, skipping customized diff")
+				d.SetNewComputed("yaml_body_parsed")
+				d.SetNewComputed("yaml_incluster")
 				return nil
 			}
 


### PR DESCRIPTION
This PR fixes the issue reported in #162 by resetting `yaml_body_parsed` and `yaml_incluster` in case `yaml_body` has been changed.