### PR TITLE
fix: Provider produced inconsistent final plan kubectl_manifest

### DIFF
--- a/kubernetes/resource_kubectl_manifest_test.go
+++ b/kubernetes/resource_kubectl_manifest_test.go
@@ -3,15 +3,16 @@ package kubernetes
 import (
 	"bytes"
 	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"testing"
+
 	"github.com/gavinbunney/terraform-provider-kubectl/yaml"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"log"
-	"os"
-	"regexp"
-	"testing"
 )
 
 func TestKubectlManifest_RetryOnFailure(t *testing.T) {


### PR DESCRIPTION
Hello all.

Terraform apply fails, if the `kubectl_manifest` property has a [string interpolate expression](https://developer.hashicorp.com/terraform/language/expressions/strings#string-templates).

More details on this error can be found in issue #162.

This PR fixes the issue by add schema.StateUpgrader to `kubectl_manifest` resource.
