### PR TITLE
Add provider option tls_server_name

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,7 @@ The following arguments are supported:
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.
 * `token` - (Optional) Token of your service account.  Can be sourced from `KUBE_TOKEN`.
 * `proxy_url` - (Optional) URL to the proxy to be used for all API requests. URLs with "http", "https", and "socks5" schemes are supported. Can be sourced from `KUBE_PROXY_URL`.
+* `tls_server_name` - (Optional) Server name passed to the server for SNI and is used in the client to check server certificates against.
 * `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
     * `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
     * `command` - (Required) Command to execute.

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -127,6 +127,12 @@ func Provider() *schema.Provider {
 				Description: "URL to the proxy to be used for all API requests",
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_PROXY_URL", ""),
 			},
+			"tls_server_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Server name passed to the server for SNI and is used in the client to check server certificates against.",
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_TLS_SERVER_NAME", ""),
+			},
 			"load_config_file": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -382,6 +388,9 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	}
 	if v, ok := d.GetOk("proxy_url"); ok {
 		overrides.ClusterDefaults.ProxyURL = v.(string)
+	}
+	if v, ok := d.GetOk("tls_server_name"); ok {
+		overrides.ClusterInfo.TLSServerName = v.(string)
 	}
 
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)


### PR DESCRIPTION
## Motivation
Support `tls_server_name` in provider configuration, same to https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#tls_server_name