### PR TITLE
Fix issues with k8s exec plugin for authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	go install
 
 dist:
-	goreleaser build --single-target --skip validate
+	goreleaser build --single-target --skip validate --clean
 
 test:
 	go test -i $(TEST) || exit 1

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ provider "kubectl" {
   load_config_file       = false
 
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws-iam-authenticator"
     args = [
       "token",
@@ -119,6 +119,24 @@ provider "kubectl" {
     ]
   }
 }
+```
+
+For a completely custom `exec`, you can parse the output of a command to get the token (such as using the aws cli directly):
+```hcl
+provider "kubectl" {
+  apply_retry_count      = 15
+  host                   = var.eks_cluster_endpoint
+  cluster_ca_certificate = base64decode(var.eks_cluster_ca)
+  load_config_file       = false
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "/bin/sh"
+    args = [
+      "-c",
+      "aws eks get-token --cluster-name ${module.eks.cluster_id} --output json"
+    ]
+  }
 ```
 
 ### Retry Support

--- a/kubernetes/provider.go
+++ b/kubernetes/provider.go
@@ -293,7 +293,9 @@ func initializeConfiguration(d *schema.ResourceData) (*restclient.Config, error)
 	}
 
 	if v, ok := d.GetOk("exec"); ok {
-		exec := &clientcmdapi.ExecConfig{}
+		exec := &clientcmdapi.ExecConfig{
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+		}
 		if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {
 			exec.APIVersion = spec["api_version"].(string)
 			exec.Command = spec["command"].(string)

--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,10 @@ func testAccCheckkubectlStatus(s *terraform.State, shouldExist bool) error {
 }
 
 func TestAccAuthExecPlugin(t *testing.T) {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
+	}
+
 	// load the kubeconfig for k3s and parse it manually
 	// so we can invoke the exec plugin path in acc tests
 	raw, err := os.ReadFile("../scripts/kubeconfig.yaml")


### PR DESCRIPTION
Recent k8s api changes for exec require explicit setting of interactive mode depending on exec api being used (underlying issue from #311). This always sets the `InteractiveMode` to `IfAvailable` to ensure compatibility. Added a test.