### PR TITLE
fix(kubectl_manifest): keep uid known during final plan expansion

### DIFF
--- a/kubernetes/resource_kubectl_manifest.go
+++ b/kubernetes/resource_kubectl_manifest.go
@@ -281,14 +281,12 @@ metadata:
 			// Get the UID of the K8s resource as it was when the `resourceKubectlManifestCreate` func completed.
 			createdAtUID := d.Get("uid").(string)
 			// Get the UID of the K8s resource as it currently is in the cluster.
-			UID, exists := d.Get("live_uid").(string)
-			if !exists {
-				return nil
-			}
+			liveUIDKnown := d.NewValueKnown("live_uid")
+			liveUID := d.Get("live_uid").(string)
 
-			if UID != createdAtUID {
-				log.Printf("[TRACE] DETECTED %s vs %s", UID, createdAtUID)
-				_ = d.SetNewComputed("uid")
+			if updatedUID, shouldUpdate := resolveUIDForPlannedState(createdAtUID, liveUID, liveUIDKnown); shouldUpdate {
+				log.Printf("[TRACE] DETECTED UID CHANGE %s vs %s", liveUID, createdAtUID)
+				_ = d.SetNew("uid", updatedUID)
 				return nil
 			}
 
@@ -876,6 +874,21 @@ func expandStringList(configured []interface{}) []string {
 func getLiveManifestFingerprint(d *schema.ResourceData, userProvided *yaml.Manifest, liveManifest *yaml.Manifest) string {
 	fields := getLiveManifestFields(d, userProvided, liveManifest)
 	return getFingerprint(fields)
+}
+
+func resolveUIDForPlannedState(createdAtUID, liveUID string, liveUIDKnown bool) (string, bool) {
+	if !liveUIDKnown {
+		return "", false
+	}
+	if createdAtUID == "" || liveUID == "" {
+		return "", false
+	}
+
+	if createdAtUID != liveUID {
+		return liveUID, true
+	}
+
+	return "", false
 }
 
 func getLiveManifestFields(d *schema.ResourceData, userProvided *yaml.Manifest, liveManifest *yaml.Manifest) string {

--- a/kubernetes/resource_kubectl_manifest_uid_test.go
+++ b/kubernetes/resource_kubectl_manifest_uid_test.go
@@ -1,0 +1,40 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveUIDForPlannedState(t *testing.T) {
+	t.Run("returns updated uid when created and live uid differ", func(t *testing.T) {
+		uid, shouldUpdate := resolveUIDForPlannedState("uid-created", "uid-live", true)
+		assert.True(t, shouldUpdate)
+		assert.Equal(t, "uid-live", uid)
+	})
+
+	t.Run("does not update when uids are equal", func(t *testing.T) {
+		uid, shouldUpdate := resolveUIDForPlannedState("uid-same", "uid-same", true)
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, "", uid)
+	})
+
+	t.Run("does not update when created uid missing", func(t *testing.T) {
+		uid, shouldUpdate := resolveUIDForPlannedState("", "uid-live", true)
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, "", uid)
+	})
+
+	t.Run("does not update when live uid missing", func(t *testing.T) {
+		uid, shouldUpdate := resolveUIDForPlannedState("uid-created", "", true)
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, "", uid)
+	})
+
+	t.Run("does not update when live uid is unknown in diff", func(t *testing.T) {
+		uid, shouldUpdate := resolveUIDForPlannedState("uid-created", "uid-live", false)
+		assert.False(t, shouldUpdate)
+		assert.Equal(t, "", uid)
+	})
+
+}


### PR DESCRIPTION


Behavior After Fix
- Prevents `.uid` from regressing from known to unknown in final plan expansion.
- Keeps existing behavior when live UID is known and truly changes.
- Reduces false-positive inconsistent-final-plan errors in `kubectl_manifest`.

How to Test
1) Run targeted regression test:
   `go -C /home/calelin/dev/terraform-provider-kubectl test ./kubernetes -run TestResolveUIDForPlannedState -count=1`

2) Run kubernetes package tests:
   `go -C /home/calelin/dev/terraform-provider-kubectl test ./kubernetes -count=1`

Test Results
1) Targeted regression test
   Command:
   `go -C /home/calelin/dev/terraform-provider-kubectl test ./kubernetes -run TestResolveUIDForPlannedState -count=1`
   Output:
   `ok  	github.com/gavinbunney/terraform-provider-kubectl/kubernetes	0.020s`

2) Kubernetes package tests
   Command:
   `go -C /home/calelin/dev/terraform-provider-kubectl test ./kubernetes -count=1`
   Output:
   `ok  	github.com/gavinbunney/terraform-provider-kubectl/kubernetes	0.026s`